### PR TITLE
ResourceUrl parameter swapping & removed $Resource parameter !publish

### DIFF
--- a/APIHelper/New-APIHelperFunction.ps1
+++ b/APIHelper/New-APIHelperFunction.ps1
@@ -51,8 +51,15 @@ $($HelpParameters -Join "`r`n")
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        `$UrlParameters = [regex]::Matches(`$ResourceUrl, '(?<!\w):\w+')
+        ForEach (`$UrlParameter in `$UrlParameters) {
+            `$UrlParameterValue = `$Parameters["`$(`$UrlParameter.Value.TrimStart(":"))"]
+            `$ResourceUrl = `$ResourceUrl -Replace `$UrlParameter.Value, `$UrlParameterValue
+        }
+
         If (-Not `$OAuthSettings) { `$OAuthSettings = Get-TwitterOAuthSettings -Resource `$Resource }
-        Invoke-TwitterAPI -Method `$Method -ResourceUrl `$ResourceUrl -Resource `$Resource -Parameters `$Parameters -OAuthSettings `$OAuthSettings
+        Invoke-TwitterAPI -Method `$Method -ResourceUrl `$ResourceUrl -Parameters `$Parameters -OAuthSettings `$OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/Invoke-TwitterAPI.ps1
+++ b/PSTwitterAPI/public/Invoke-TwitterAPI.ps1
@@ -5,18 +5,12 @@ function Invoke-TwitterAPI {
         [Parameter(Mandatory)]
         [string]$ResourceUrl,
         [Parameter(Mandatory)]
-        [string]$Resource,
-        [Parameter(Mandatory)]
         [string]$Method,
         [Parameter(Mandatory)]
         $Parameters,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory)]
         $OAuthSettings
     )
-
-    If (-Not($OAuthSettings)) {
-        $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource
-    }
 
     $OAuthParameters_Params = @{}
     $OAuthParameters_Params['ApiKey'] = $OAuthSettings.ApiKey

--- a/PSTwitterAPI/public/helper/Get-TwitterAccount_Settings.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterAccount_Settings.ps1
@@ -30,8 +30,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterAccount_VerifyCredentials.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterAccount_VerifyCredentials.ps1
@@ -48,8 +48,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterApplication_RateLimitStatus.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterApplication_RateLimitStatus.ps1
@@ -42,8 +42,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterBlocks_Ids.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterBlocks_Ids.ps1
@@ -39,8 +39,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterBlocks_List.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterBlocks_List.ps1
@@ -43,8 +43,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterCollections_Entries.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterCollections_Entries.ps1
@@ -48,8 +48,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterCollections_List.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterCollections_List.ps1
@@ -50,8 +50,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterCollections_Show.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterCollections_Show.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterCustomProfiles_List.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterCustomProfiles_List.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterCustomProfiles__Id.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterCustomProfiles__Id.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_EventsList.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_EventsList.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_EventsShow.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_EventsShow.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesList.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesList.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesRulesList.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesRulesList.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesRulesShow.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesRulesShow.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesShow.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterDirectMessages_WelcomeMessagesShow.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFavorites_List.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFavorites_List.ps1
@@ -54,8 +54,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFollowers_IDs.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFollowers_IDs.ps1
@@ -53,8 +53,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFollowers_List.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFollowers_List.ps1
@@ -55,8 +55,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFriends_IDs.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFriends_IDs.ps1
@@ -53,8 +53,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFriends_List.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFriends_List.ps1
@@ -55,8 +55,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFriendships_Incoming.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFriendships_Incoming.ps1
@@ -37,8 +37,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFriendships_Lookup.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFriendships_Lookup.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFriendships_NoRetweetsIds.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFriendships_NoRetweetsIds.ps1
@@ -34,8 +34,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFriendships_Outgoing.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFriendships_Outgoing.ps1
@@ -37,8 +37,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterFriendships_Show.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterFriendships_Show.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterGeo_Id_PlaceId.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterGeo_Id_PlaceId.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterGeo_ReverseGeocode.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterGeo_ReverseGeocode.ps1
@@ -51,8 +51,15 @@ Setting this to city, for example, will find places which have a type of city, a
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterGeo_Search.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterGeo_Search.ps1
@@ -72,8 +72,15 @@ Specify a place_id. For example, to scope all results to places within "San Fran
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterHelp_Configuration.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterHelp_Configuration.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterHelp_Languages.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterHelp_Languages.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterHelp_Privacy.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterHelp_Privacy.ps1
@@ -30,8 +30,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterHelp_Tos.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterHelp_Tos.ps1
@@ -30,8 +30,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_Members.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_Members.ps1
@@ -66,8 +66,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_MembersShow.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_MembersShow.ps1
@@ -60,8 +60,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_Memberships.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_Memberships.ps1
@@ -48,8 +48,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_Ownerships.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_Ownerships.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_Show.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_Show.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_Statuses.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_Statuses.ps1
@@ -66,8 +66,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_Subscribers.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_Subscribers.ps1
@@ -62,8 +62,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_SubscribersShow.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_SubscribersShow.ps1
@@ -60,8 +60,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_Subscriptions.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_Subscriptions.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterLists_list.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterLists_list.ps1
@@ -42,8 +42,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterMutes_UsersIds.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterMutes_UsersIds.ps1
@@ -37,8 +37,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterMutes_UsersList.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterMutes_UsersList.ps1
@@ -41,8 +41,15 @@ The response from the API will include a previous_cursor and next_cursor to allo
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterOauth_Authenticate.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterOauth_Authenticate.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterOauth_Authorize.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterOauth_Authorize.ps1
@@ -38,8 +38,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterSavedSearches_List.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterSavedSearches_List.ps1
@@ -30,8 +30,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterSavedSearches_Show_Id.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterSavedSearches_Show_Id.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterSearch_Tweets.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterSearch_Tweets.ps1
@@ -75,8 +75,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_HomeTimeline.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_HomeTimeline.ps1
@@ -56,8 +56,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_Lookup.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_Lookup.ps1
@@ -64,8 +64,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_MentionsTimeline.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_MentionsTimeline.ps1
@@ -54,8 +54,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_RetweetersIds.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_RetweetersIds.ps1
@@ -48,8 +48,15 @@ While this method supports the cursor parameter, the entire result set can be re
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_RetweetsOfMe.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_RetweetsOfMe.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_Retweets_Id.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_Retweets_Id.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_Sample.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_Sample.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_Show_Id.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_Show_Id.ps1
@@ -60,8 +60,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterStatuses_UserTimeline.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterStatuses_UserTimeline.ps1
@@ -70,8 +70,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterTrends_Available.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterTrends_Available.ps1
@@ -34,8 +34,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterTrends_Closest.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterTrends_Closest.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterTrends_Place.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterTrends_Place.ps1
@@ -42,8 +42,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterUsers_Lookup.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterUsers_Lookup.ps1
@@ -56,8 +56,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterUsers_ProfileBanner.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterUsers_ProfileBanner.ps1
@@ -38,8 +38,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterUsers_Search.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterUsers_Search.ps1
@@ -46,8 +46,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterUsers_Show.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterUsers_Show.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Get-TwitterUsers_Suggestions_SlugMembers.ps1
+++ b/PSTwitterAPI/public/helper/Get-TwitterUsers_Suggestions_SlugMembers.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Remove-TwitterCustomProfiles_Destroy.ps1
+++ b/PSTwitterAPI/public/helper/Remove-TwitterCustomProfiles_Destroy.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterAccount_RemoveProfileBanner.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterAccount_RemoveProfileBanner.ps1
@@ -30,8 +30,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterAccount_Settings.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterAccount_Settings.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfile.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfile.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfileBackgroundImage.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfileBackgroundImage.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfileBanner.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfileBanner.ps1
@@ -57,8 +57,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfileImage.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterAccount_UpdateProfileImage.ps1
@@ -42,8 +42,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterBlocks_Create.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterBlocks_Create.ps1
@@ -46,8 +46,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterBlocks_Destroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterBlocks_Destroy.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCollections_Create.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCollections_Create.ps1
@@ -42,8 +42,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCollections_Destroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCollections_Destroy.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesAdd.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesAdd.ps1
@@ -48,8 +48,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesCurate.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesCurate.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesMove.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesMove.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesRemove.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCollections_EntriesRemove.ps1
@@ -38,8 +38,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCollections_Update.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCollections_Update.ps1
@@ -42,8 +42,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterCustomProfiles_New.Json.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterCustomProfiles_New.Json.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_EventsNew.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_EventsNew.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_IndicateTyping.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_IndicateTyping.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_MarkRead.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_MarkRead.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_WelcomeMessagesNew.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_WelcomeMessagesNew.ps1
@@ -34,8 +34,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_WelcomeMessagesRulesNew.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterDirectMessages_WelcomeMessagesRulesNew.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterFavorites_Create.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterFavorites_Create.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterFavorites_Destroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterFavorites_Destroy.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterFriendships_Create.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterFriendships_Create.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterFriendships_Destroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterFriendships_Destroy.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterFriendships_Update.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterFriendships_Update.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_Create.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_Create.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_Destroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_Destroy.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_MembersCreate.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_MembersCreate.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_MembersCreateAll.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_MembersCreateAll.ps1
@@ -54,8 +54,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_MembersDestroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_MembersDestroy.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_MembersDestroyAll.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_MembersDestroyAll.ps1
@@ -54,8 +54,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_SubscribersCreate.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_SubscribersCreate.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_SubscribersDestroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_SubscribersDestroy.ps1
@@ -44,8 +44,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterLists_Update.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterLists_Update.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterMedia_MetadataCreate.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterMedia_MetadataCreate.ps1
@@ -48,8 +48,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterMedia_SubtitlesCreate.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterMedia_SubtitlesCreate.ps1
@@ -54,8 +54,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterMedia_SubtitlesDelete.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterMedia_SubtitlesDelete.ps1
@@ -50,8 +50,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterMedia_Upload.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterMedia_Upload.ps1
@@ -66,8 +66,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterMutes_UsersCreate.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterMutes_UsersCreate.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterMutes_UsersDestroy.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterMutes_UsersDestroy.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterOauth2_InvalidateToken.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterOauth2_InvalidateToken.ps1
@@ -34,8 +34,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterOauth2_Token.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterOauth2_Token.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterOauth_AccessToken.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterOauth_AccessToken.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterOauth_InvalidateToken.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterOauth_InvalidateToken.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterOauth_RequestToken.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterOauth_RequestToken.ps1
@@ -41,8 +41,15 @@ We require that any callback URL used with this endpoint will have to be whiteli
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterSavedSearches_Create.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterSavedSearches_Create.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterSavedSearches_Destroy_Id.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterSavedSearches_Destroy_Id.ps1
@@ -32,8 +32,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterStatuses_Destroy_Id.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterStatuses_Destroy_Id.ps1
@@ -36,8 +36,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterStatuses_Filter.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterStatuses_Filter.ps1
@@ -52,8 +52,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterStatuses_Retweet_Id.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterStatuses_Retweet_Id.ps1
@@ -42,8 +42,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterStatuses_Unretweet_Id.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterStatuses_Unretweet_Id.ps1
@@ -43,8 +43,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterStatuses_Update.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterStatuses_Update.ps1
@@ -102,8 +102,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterStatuses_UpdateWithMedia.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterStatuses_UpdateWithMedia.ps1
@@ -50,8 +50,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {

--- a/PSTwitterAPI/public/helper/Send-TwitterUsers_ReportSpam.ps1
+++ b/PSTwitterAPI/public/helper/Send-TwitterUsers_ReportSpam.ps1
@@ -40,8 +40,15 @@
     }
     Process {
 
+        # Find & Replace any ResourceUrl parameters.
+        $UrlParameters = [regex]::Matches($ResourceUrl, '(?<!\w):\w+')
+        ForEach ($UrlParameter in $UrlParameters) {
+            $UrlParameterValue = $Parameters["$($UrlParameter.Value.TrimStart(":"))"]
+            $ResourceUrl = $ResourceUrl -Replace $UrlParameter.Value, $UrlParameterValue
+        }
+
         If (-Not $OAuthSettings) { $OAuthSettings = Get-TwitterOAuthSettings -Resource $Resource }
-        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Resource $Resource -Parameters $Parameters -OAuthSettings $OAuthSettings
+        Invoke-TwitterAPI -Method $Method -ResourceUrl $ResourceUrl -Parameters $Parameters -OAuthSettings $OAuthSettings
 
     }
     End {


### PR DESCRIPTION
Added subroutine to replace ResourceUrl parameters
Example : https://api.twitter.com/1.1/geo/id/:place_id.json
Becomes: https://api.twitter.com/1.1/geo/id/df51dec6f4ee2b2c.json

Removed $Resource parameter from Invoke-TwitterAPI function